### PR TITLE
Added TravisCI running YAML script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ node_js:
           - '8'
           - '7'
           - '6'
-# the following step should start the xvfb process         
+# the following step should start the virtual X frame buffer: Xvfb process         
 before_script:
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 #wait a while before xvfb to start

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,31 @@
+sudo: required
+dist: trusty
+cache:
+  directories:
+    - node_modules
 language: node_js
+env:
+  global:
+    - CXX=g++-4.8
+    - DISPLAY=:99.0
+    - CHROME_BIN=/usr/bin/google-chrome
+# setting up Chrome for e2e tests
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+      - oracle-java8-set-default
+
+# Building for a specific set of node versions
 node_js:
-          - '8.8.1'
+          - '8'
+          - '7'
+          - '6'
+# the following step should start the xvfb process         
+before_script:
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 #wait a while before xvfb to start
+after_script:
+  - "sh -e /etc/init.d/xvfb stop"

--- a/test/e2e/specs/test.js
+++ b/test/e2e/specs/test.js
@@ -11,9 +11,7 @@ module.exports = {
     browser
       .url(devServer)
       .waitForElementVisible('#app', 5000)
-      .assert.elementPresent('.hello')
-      .assert.containsText('h1', 'Welcome to Your Vue.js App')
-      .assert.elementCount('img', 1)
+      .assert.elementPresent('#background')
       .end()
   }
 }


### PR DESCRIPTION
This fixes #23.

It adds the following:

- an e2e test asserting that both divs identified as `app` and `background` are built by Vue instance;
- a fix to `.travis.yml` that adds the support to start a valid Selenium server (i.e.: a Chrome instance) before the `npm test` execution.