### PR TITLE
removing eslint warning by adding :key bindings to v-for

### DIFF
--- a/src/components/AddAutomation.vue
+++ b/src/components/AddAutomation.vue
@@ -11,7 +11,7 @@
         <div>
            <!-- This should be replaced by md-select component -->
            <select id="trigger" v-model="selectedTrigger">
-              <option v-for="trigger in getTriggersList" v-bind:value="trigger">
+              <option v-for="trigger in getTriggersList" v-bind:value="trigger" :key='trigger.uuid'>
                   {{ trigger.name }}
               </option>
            </select>
@@ -34,7 +34,7 @@
       <md-step id="third" :md-label="$t('review_confirm')" :md-done.sync="third">
         <div>Selected trigger: {{ selectedTrigger['name'] }}</div>
         <div>Selected commands: 
-          <li v-for="command in selectedCommands">
+          <li v-for="command in selectedCommands" :key='command.uuid'>
              {{ command['name'] }}
           </li>
         </div>  

--- a/src/components/Thing.vue
+++ b/src/components/Thing.vue
@@ -61,7 +61,7 @@
               <md-switch v-if="behavior['@class'] == 'com.freedomotic.model.object.BooleanBehavior'" v-model="behavior.value" @change="changeBehavior(getThingFromStore.uuid, behavior.name, !!behavior.value)"></md-switch>
               <vue-slider v-if="behavior['@class'] == 'com.freedomotic.model.object.RangedIntBehavior'" ref="getThingFromStore.name + '-' + behavior.name" v-model="behavior.value" :min="Number(behavior.min/behavior.scale)" :max="Number(behavior.max/behavior.scale)" @click.native="changeBehavior(getThingFromStore.uuid, behavior.name, behavior.value)" tooltip="false"></vue-slider>
             <select v-if="behavior['@class'] == 'com.freedomotic.model.object.ListBehavior'" v-model="behavior.selected">
-              <option v-for="(item, index) in behavior.list" v-bind:value="index" @change="changeBehavior(getThingFromStore.uuid, behavior.name, item)">{{item}}</option>
+              <option v-for="(item, index) in behavior.list" :key="index" v-bind:value="index" @change="changeBehavior(getThingFromStore.uuid, behavior.name, item)">{{item}}</option>
             </select>
             </div> 
           </md-card-content>

--- a/src/components/ThingsEditor.vue
+++ b/src/components/ThingsEditor.vue
@@ -77,7 +77,7 @@
         </md-field>
        </v-tab>
        <v-tab :title="$t('data_source')">
-        <div v-for="trigger in thing.triggers.propertyList">
+        <div v-for="trigger in thing.triggers.propertyList" :key="trigger.uuid">
            {{trigger}}
         <span>
          <select>
@@ -89,7 +89,7 @@
         </div>
        </v-tab>
        <v-tab :title="$t('actions')">
-        <div v-for="(value, key) in thing.actions.propertyList">
+        <div v-for="(value, key) in thing.actions.propertyList" :key="key">
            {{key}}
         </div>
        </v-tab>

--- a/src/components/mobile/mobile-pages/Automation.vue
+++ b/src/components/mobile/mobile-pages/Automation.vue
@@ -11,7 +11,7 @@
       <v-ons-list-item>
         <div class="center">
           <select id="trigger" v-model="selectedTrigger">
-              <option v-for="trigger in getTriggersList" :value="trigger">
+              <option v-for="trigger in getTriggersList" :value="trigger"  :key='trigger.uuid'>
                   {{ trigger.name }}
               </option>
           </select>
@@ -24,7 +24,7 @@
       <v-ons-list-item>
         <div class="center">
           <select v-model="selectedCommands" multiple style="width: 40%">
-            <option v-for="command in getCommandsList" :value="command">
+            <option v-for="command in getCommandsList" :value="command" :key='command.uuid'>
               {{ command.name}}
             </option>
           </select>
@@ -34,7 +34,7 @@
     <br>
     <div>Selected trigger: {{ selectedTrigger}}</div>
         <div>Selected commands: 
-          <li v-for="command in selectedCommands">
+          <li v-for="command in selectedCommands" :key='command.uuid'>
              {{ command.name }}
           </li>
         </div>  

--- a/src/components/mobile/mobile-pages/Thing.vue
+++ b/src/components/mobile/mobile-pages/Thing.vue
@@ -8,7 +8,7 @@
           <v-ons-select style="width: 40%"
             v-model="selectedSection"
           >
-            <option v-for="section in sections" :value="section.value">
+            <option v-for="(section, key) in sections" :value="section.value" :key='key'>
               {{ $t(section.text) }}
             </option>
           </v-ons-select>
@@ -115,7 +115,7 @@
        <div class="center">
          <label v-if="this.$ons.platform.isIOS()" for="environment">{{$t('environment')}}</label>
          <v-ons-select v-model="environment" name="environment">
-            <option v-for="env in getEnvironmentsList" :value="env.uuid">
+            <option v-for="env in getEnvironmentsList" :value="env.uuid" :key='env.uuid'>
               {{ env.name }}
             </option>
           </v-ons-select>


### PR DESCRIPTION
This solves #174.
It fixes the warning by adding the `:key` binding to all the `v-for` occurrences without it.