### PR TITLE
Add auto detection of Language

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -49,7 +49,10 @@ import MobileCommand from './components/mobile/mobile-pages/Command.vue'
 Vue.use(VueAxios, axios)
 Vue.use(VueMaterial)
 Vue.use(Snotify)
-Vue.use(VModal, { dialog: true, dynamic: true })
+Vue.use(VModal, {
+  dialog: true,
+  dynamic: true
+})
 Vue.use(VueTabs)
 
 // VueOnsen components
@@ -90,6 +93,21 @@ if (token) {
   console.log('No authentication token found')
 }
 
+// Map of navigator language with the corresponding value
+
+const mapLanguage = {
+  'it-it': 'it',
+  'en-en': 'en',
+  'en': 'en',
+  'nl': 'nl',
+  'nl-be': 'nl',
+  'ro': 'ro',
+  'ro-mo': 'ro',
+  'ru': 'ru',
+  'ru-mo': 'ru',
+  'sk': 'sk'
+}
+
 Vue.config.productionTip = false
 
 Vue.directive('focus', {
@@ -106,5 +124,14 @@ new Vue({
   router,
   store,
   template: '<App/>',
-  components: { App }
+  components: {
+    App
+  },
+  mounted () {
+    // lowercase for new and old browser
+    const language = window.navigator.language.toLocaleLowerCase()
+    if (!(mapLanguage[language] === undefined)) {
+      this.$i18n.set(mapLanguage[language])
+    }
+  }
 })


### PR DESCRIPTION
Issue related to #9 

Add auto detection of language using navigator.language, i create an object with key and value.
Keys are the values can be returned by navigator.languages ( list [here](https://www.metamodpro.com/browser-language-codes) and values are our label for i18n translation files.

Navigator language is set to lowercase for support also safari < 10.2  ([here](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language))

I wanted to add test too, but test suite pass every time, even if i try to write test that fail.

I hope my contribution can be useful
