### PR TITLE
Change menu icons on ThingsEditor

### DIFF
--- a/src/components/ThingsEditor.vue
+++ b/src/components/ThingsEditor.vue
@@ -5,11 +5,11 @@
     <q-splitter v-model="splitterModel">
       <template v-slot:before>
         <q-tabs v-model="tab" vertical class="text-teal">
-          <q-tab name="properties" icon="mail" label="Properties" />
-          <q-tab name="appearance" icon="alarm" label="Appearance" />
-          <q-tab name="dataSource" icon="movie" label="Data Source" />
-          <q-tab name="actions" icon="movie" label="Actions" />
-          <q-tab name="controlPanel" icon="movie" label="Control Panel" />
+          <q-tab name="properties" icon="list_alt" label="Properties" />
+          <q-tab name="appearance" icon="brush" label="Appearance" />
+          <q-tab name="dataSource" icon="storage" label="Data Source" />
+          <q-tab name="actions" icon="touch_app" label="Actions" />
+          <q-tab name="controlPanel" icon="tune" label="Control Panel" />
         </q-tabs>
       </template>
 


### PR DESCRIPTION
Resolves issue #225 

Using Google's Material Icons the final result is:

![things-editor-modified](https://user-images.githubusercontent.com/26444579/95653024-ac5d6800-0af5-11eb-8641-cbcc7015dae5.png)


Note: If you plan to switch to [mdi](https://materialdesignicons.com/) (that includes all of the Google's icons) there are some icons that I feel are more appropriate like this one for "Data source":

![mdi-database](https://user-images.githubusercontent.com/26444579/95653065-02321000-0af6-11eb-858e-46fd44581f64.png)

