### PR TITLE
Disable expand behaviours when the list is empty

### DIFF
--- a/src/components/Thing.vue
+++ b/src/components/Thing.vue
@@ -50,6 +50,7 @@
           round
           flat
           dense
+          :disable="expandBehaviorsDisabled"
           :icon="expanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'"
           @click="expanded = !expanded"
         />
@@ -235,6 +236,18 @@ export default {
   computed: {
     getThingFromStore: function() {
       return this.$store.state.thingsList[this.index];
+    },
+
+    expandBehaviorsDisabled: function() {
+      let isDisabled = false;
+
+      if (!this.getThingFromStore.behaviors || !this.getThingFromStore.behaviors.length) {
+        isDisabled = true;
+      } else {
+        isDisabled = this.getThingFromStore.behaviors.filter(b => !b.readOnly).length <= 0;
+      }
+
+      return isDisabled;
     }
   },
   methods: {


### PR DESCRIPTION
Fixes #228 

Side note: The termometer Thing have the arrow enabled even if it shows nothing because the thing.behaviours list contains an object. Here a console log of the thermometer behavior
`
{"@class":"com.freedomotic.model.object.RangedIntBehavior","name":"temperature","description":"","active":true,"priority":-1,"readOnly":true,"value":0,"max":1000,"min":-600,"scale":10,"step":1}
`