### PR TITLE
Info messages are now in green and positioned at the top.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,11 @@ export default {
     EventBus.$on('notifyMessage', function (type, message) {
       switch (type) {
         case 'info':
-            this.$q.notify(message)
+            this.$q.notify({
+              message,
+              color: 'green',
+              position: 'top'
+            });
           break
       }
     })


### PR DESCRIPTION
Fixes issue: #232 

Well that was easy. I was thinking about configuring Freedomotic locally to just to demonstrate that the dialog changes worked... But luckily that wasn't needed.